### PR TITLE
Add install and typescript to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,37 @@ Each player object contains direction and button actions. These are updated by t
 . Check for gamepad button presses (i.e. ‘justDown()’ functionality for gamepads)  
 . Check the last device type used for interaction.  
 
+## Installation
+
+```
+npm install phaser3-merged-input
+```
+
+Then add the plugin to Phaser 3's configuration:
+
+```javascript
+const config = {
+  plugins: {
+    scene: [
+      {
+        key: "mergedInput",
+        plugin: MergedInput,
+        mapping: "mergedInput",
+      },
+    ],
+  }
+};
+```
+
+### TypeScript
+
+You will also need to add a class member to the scene so TypeScript knows how to type it. The member name **must** have the same name as the value the `mapping` property specified in the Phaser configuration above, or the plugin won't work. **Example**:
+
+```typescript
+class InputController extends Phaser.Scene {
+  private mergedInput?: MergedInput;
+```
+
 ## Setup
 Set up a player object for each player in your game with `addPlayer()`.
 Then assign keys to each action with the `defineKey()` function, e.g.

--- a/README.md
+++ b/README.md
@@ -21,30 +21,45 @@ Each player object contains direction and button actions. These are updated by t
 npm install phaser3-merged-input
 ```
 
-Then add the plugin to Phaser 3's configuration:
+Then you can add the plugin to Phaser 3's global configuration:
 
 ```javascript
 const config = {
-  plugins: {
-    scene: [
-      {
-        key: "mergedInput",
-        plugin: MergedInput,
-        mapping: "mergedInput",
-      },
-    ],
-  }
+    plugins: {
+        scene: [
+            {
+                key: "mergedInput",
+                plugin: MergedInput,
+                mapping: "mergedInput",
+            },
+        ],
+    }
 };
+```
+
+Or using a scene's local configuration:
+
+```javascript
+class InputController extends Phaser.Scene {
+    preload() {
+        this.load.scenePlugin('mergedInput', MergedInput);
+    }
 ```
 
 ### TypeScript
 
-You will also need to add a class member to the scene so TypeScript knows how to type it. The member name **must** have the same name as the value the `mapping` property specified in the Phaser configuration above, or the plugin won't work. **Example**:
+You will also need to add a class member to the scene so TypeScript knows how to type it.
+
+**Example**:
 
 ```typescript
 class InputController extends Phaser.Scene {
-  private mergedInput?: MergedInput;
+    private mergedInput?: MergedInput;
 ```
+
+If you're using the Phaser global config for the plugin, the member name **must** have the same name as the value the `mapping` property specified in the Phaser configuration above, or the plugin won't work.
+
+If you're using the scene local plugin, the member name **must** match the key specified in `scenePlugin(key, ...)`.
 
 ## Setup
 Set up a player object for each player in your game with `addPlayer()`.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Each player object contains direction and button actions. These are updated by t
 npm install phaser3-merged-input
 ```
 
-Then you can add the plugin to Phaser 3's global configuration:
+Then you can either add the plugin to Phaser 3's global configuration:
 
 ```javascript
 const config = {
@@ -45,10 +45,11 @@ class InputController extends Phaser.Scene {
         this.load.scenePlugin('mergedInput', MergedInput);
     }
 ```
+  
 
 ### TypeScript
 
-You will also need to add a class member to the scene so TypeScript knows how to type it.
+If you're using TypeScript, you will also need to add a class member to the scene so TypeScript knows how to type it.
 
 **Example**:
 
@@ -59,7 +60,9 @@ class InputController extends Phaser.Scene {
 
 If you're using the Phaser global config for the plugin, the member name **must** have the same name as the value the `mapping` property specified in the Phaser configuration above, or the plugin won't work.
 
-If you're using the scene local plugin, the member name **must** match the key specified in `scenePlugin(key, ...)`.
+If you're using the scene local plugin, the member name **must** match the key specified in `scenePlugin(key, ...)`.    
+
+---
 
 ## Setup
 Set up a player object for each player in your game with `addPlayer()`.


### PR DESCRIPTION
I was looking for a plugin like this and just came across it moments ago, how fortuitous for me that TypeScript was just merged with #16 a couple of hours ago! It's working great so far.

I couldn't find a way to make this work without TypeScript complaining about types, and found [a thread](https://phaser.discourse.group/t/how-to-use-plugins-in-phaser-with-typescript/10778/9) about a different plugin which was helpful. 

I added some instructions to the README for installation and for usage with TypeScript.

@zewa666 maybe you want to take a look too in case I missed something?