### PR TITLE
Use Phaser KeyCodes for defineKey

### DIFF
--- a/main.d.ts
+++ b/main.d.ts
@@ -1,6 +1,7 @@
 declare module 'phaser3-merged-input' {
   import * as Phaser from "phaser";
 
+  export type KeyCode = keyof typeof Phaser.Input.Keyboard.KeyCodes;
   export type Bearing = "" | "W" | "NW" | "N" | "NE" | "E" | "SE" | "S" | "SW";
   export interface Player {
     direction: {
@@ -221,7 +222,7 @@ declare module 'phaser3-merged-input' {
      * @param {string} value The key to use
      * @param {boolean} append When true, this key definition will be appended to the existing key(s) for this action
      */
-    defineKey(player: number, action: string, value: string, append?: boolean): MergedInput;
+    defineKey(player: number, action: string, value: KeyCode, append?: boolean): MergedInput;
     /**
      * Iterate through players and check for interaction with defined keys
      */


### PR DESCRIPTION
defineKey's `value` was loosely typed as a String, but as far as I can tell from the code it's intended to be a value from the Phaser KeyCodes. This types `value` more strictly to be the specific inputs.

cc @zewa666

![example](https://user-images.githubusercontent.com/438465/156884740-b268f339-fff8-4495-b285-d7b29252a6de.png)
 